### PR TITLE
SoC: exynos: add support for exynos 8890

### DIFF
--- a/arch/arm/dts/exynos8890-gpio.dtsi
+++ b/arch/arm/dts/exynos8890-gpio.dtsi
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Samsung's Exynos8890 SoC pin-mux and pin-config device tree source
+ *
+ * Copyright (c) 2013 Samsung Electronics Co., Ltd.
+ *		http://www.samsung.com
+ * Copyright (c) 2022 Suraaj Vashisht (suraajvashisht@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/ {
+	/* ALIVE */
+	gpio@10580000 {
+		gpa0: gpa0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpa1: gpa1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpa2: gpa2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpa3: gpa3 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* AUD */
+	gpio@114B0000 {
+		gph0: gph0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* CCORE */
+	gpio@105A0000 {
+		etc0: etc0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* FP */
+	gpio@14CA0000 {
+		gpf3: gpf3 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* FSYS0 */
+	gpio@10E60000 {
+		gpi1: gpi1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+		gpi2: gpi2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* FSYS1 */
+	gpio@15690000 {
+		gpj0: gpj0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* PERIC0 */
+	gpio@136D0000 {
+		gpi0: gpi0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpd0: gpd0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpd1: gpd1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpd2: gpd2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpd3: gpd3 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpb1: gpb1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpb2: gpb2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpb0: gpb0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpc0: gpc0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpc1: gpc1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpc2: gpc2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpc3: gpc3 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+
+		gpk0: gpk0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		etc1: etc1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/* PERIC1 */
+	gpio@14CC0000 {
+		gpe0: gpe0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe5: gpe5 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe6: gpe6 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpj1: gpj1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpj2: gpj2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe2: gpe2 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe3: gpe3 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe4: gpe4 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe1: gpe1 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpe7: gpe7 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpg0: gpg0 {
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+};

--- a/arch/arm/dts/exynos8890-pinctrl.dtsi
+++ b/arch/arm/dts/exynos8890-pinctrl.dtsi
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Samsung's Exynos8890 SoC pin-mux and pin-config device tree source
+ *
+ * Copyright (c) 2013 Samsung Electronics Co., Ltd.
+ *		http://www.samsung.com
+ * Copyright (c) 2022 Suraaj Vashisht (suraajvashisht@gmail.com)
+ *
+ * Samsung's Exynos8890 SoC pin-mux and pin-config options are listed as device
+ * tree nodes are listed in this file.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+*/
+
+/ {
+	/* ALIVE */
+	pinctrl@10580000 {
+		dwmmc2_cd_ext_irq: dwmmc2_cd_ext_irq {
+			samsung,pins = "gpa1-5";
+			samsung,pin-function = <0xf>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		pcie_wake: pcie_wake {
+			samsung,pins = "gpa3-3";
+			samsung,pin-function = <0>;
+			samsung,pin-pud = <0>;
+		};
+	};
+
+	/* AUD */
+	pinctrl@114B0000 {
+		i2s0_bus: i2s0-bus {
+			samsung,pins = "gph0-0", "gph0-1", "gph0-2", "gph0-3",
+					"gph0-4", "gph0-5", "gph0-6";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <2>;
+		};
+
+		i2s0_bus_idle: i2s0-bus-idle {
+			samsung,pins = "gph0-0", "gph0-1", "gph0-2", "gph0-3",
+					"gph0-4", "gph0-5", "gph0-6";
+			samsung,pin-function = <0>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <2>;
+		};
+	};
+
+	/* CCORE */
+	pinctrl@105A0000 {
+		hs_i2c15_bus: hs-i2c15-bus {
+			samsung,pins = "etc0-1", "etc0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+			samsung,pin-con-pdn = <3>;
+		};
+
+		hs_i2c15_apm: hs-i2c15-apm {
+			samsung,pins = "etc0-1", "etc0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+			samsung,pin-con-pdn = <3>;
+		};
+	};
+
+	/* FSYS1 */
+	pinctrl@15690000 {
+		sd2_clk: sd2-clk {
+			samsung,pins = "gpj0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <2>;
+		};
+
+		sd2_cmd: sd2-cmd {
+			samsung,pins = "gpj0-1";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <2>;
+		};
+
+		sd2_bus1: sd2-bus-width1 {
+			samsung,pins = "gpj0-3";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		sd2_bus4: sd2-bus-width4 {
+			samsung,pins = "gpj0-4", "gpj0-5", "gpj0-6";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		/* For Drive strength swapping */
+		sd2_clk_fast_slew_rate_1x: sd2-clk_fast_slew_rate_1x {
+			samsung,pins = "gpj0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		sd2_clk_fast_slew_rate_2x: sd2-clk_fast_slew_rate_2x {
+			samsung,pins = "gpj0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		sd2_clk_fast_slew_rate_3x: sd2-clk_fast_slew_rate_3x {
+			samsung,pins = "gpj0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <2>;
+		};
+
+		sd2_clk_fast_slew_rate_4x: sd2-clk_fast_slew_rate_4x {
+			samsung,pins = "gpj0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <3>;
+		};
+	};
+
+	/* PERIC0 */
+	pinctrl@136D0000 {
+		etc1_5: etc1_5 {
+			samsung,pins = "etc1-5";
+			samsung,pin-con-pdn = <3>;
+			samsung,pin-pud-pdn = <1>;
+		};
+
+		fimc_is_mclk0_in: fimc_is_mclk0_in {
+			samsung,pins = "gpk0-0";
+			samsung,pin-function = <0>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <2>;
+		};
+
+		fimc_is_mclk1_in: fimc_is_mclk1_in {
+			samsung,pins = "gpk0-1";
+			samsung,pin-function = <0>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_mclk2_in: fimc_is_mclk2_in {
+			samsung,pins = "gpk0-2";
+			samsung,pin-function = <0>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		fimc_is_mclk3_in: fimc_is_mclk3_in {
+			samsung,pins = "gpk0-3";
+			samsung,pin-function = <0>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		fimc_is_mclk0_out: fimc_is_mclk0_out {
+			samsung,pins = "gpk0-0";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <2>;
+		};
+
+		fimc_is_mclk1_out: fimc_is_mclk1_out {
+			samsung,pins = "gpk0-1";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_mclk2_out: fimc_is_mclk2_out {
+			samsung,pins = "gpk0-2";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <1>;
+		};
+
+		fimc_is_mclk3_out: fimc_is_mclk3_out {
+			samsung,pins = "gpk0-3";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <1>;
+		};
+
+		fimc_is_mclk0_fn: fimc_is_mclk0_fn {
+			samsung,pins = "gpk0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <2>;
+		};
+
+		fimc_is_mclk1_fn: fimc_is_mclk1_fn {
+			samsung,pins = "gpk0-1";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_mclk2_fn: fimc_is_mclk2_fn {
+			samsung,pins = "gpk0-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		fimc_is_mclk3_fn: fimc_is_mclk3_fn {
+			samsung,pins = "gpk0-3";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <1>;
+		};
+
+		fimc_is_i2c0: fimc_is_i2c0 {
+			samsung,pins = "gpc2-1", "gpc2-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_i2c1: fimc_is_i2c1 {
+			samsung,pins = "gpc2-3", "gpc2-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_i2c1_out: fimc_is_i2c1_out {
+			samsung,pins = "gpc2-3", "gpc2-2";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+
+		fimc_is_i2c2: fimc_is_i2c2 {
+			samsung,pins = "gpc2-5", "gpc2-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_flash: fimc-is-flash {
+			samsung,pins = "gpc0-3", "gpc1-1";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_spi_pin0: fimc-is-spi-pin0 {
+			samsung,pins = "gpc3-3", "gpc3-2", "gpc3-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+
+		fimc_is_spi_pin0_out: fimc-is-spi-pin0-out {
+			samsung,pins = "gpc3-3", "gpc3-2", "gpc3-0";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+
+		fimc_is_spi_pin0_fn: fimc-is-spi-pin0-fn {
+			samsung,pins = "gpc3-3", "gpc3-2", "gpc3-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+
+		fimc_is_spi_pin1: fimc-is-spi-pin1 {
+			samsung,pins = "gpc3-7", "gpc3-6", "gpc3-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+
+		fimc_is_spi_pin1_out: fimc-is-spi-pin1-out {
+			samsung,pins = "gpc3-7", "gpc3-6", "gpc3-4";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+
+		fimc_is_spi_pin1_fn: fimc-is-spi-pin1-fn {
+			samsung,pins = "gpc3-7", "gpc3-6", "gpc3-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+			samsung,pin-val = <0>;
+		};
+		
+		fimc_is_spi_ssn0_out: fimc-is-spi-ssn0-out {
+			samsung,pins = "gpc3-1";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_spi_ssn0_fn: fimc-is-spi-ssn0-fn {
+			samsung,pins = "gpc3-1";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_spi_ssn1_out: fimc-is-spi-ssn1-out {
+			samsung,pins = "gpc3-5";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		fimc_is_spi_ssn1_fn: fimc-is-spi-ssn1-fn {
+			samsung,pins = "gpc3-5";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+
+		uart_isp_bus: uart-isp-bus {
+			samsung,pins = "gpc1-4", "gpc1-3", "gpc1-2", "gpc1-1";
+			samsung,pin-function = <3>;
+			samsung,pin-pud = <0>;
+		};
+
+		uart0_bus: uart0-bus {
+			samsung,pins = "gpd0-3", "gpd0-2", "gpd0-1", "gpd0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		hs_i2c0_bus: hs-i2c0-bus {
+			samsung,pins = "gpd1-1", "gpd1-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c1_bus: hs-i2c1-bus {
+			samsung,pins = "gpd1-3", "gpd1-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c9_bus: hs-i2c9-bus {
+			samsung,pins = "gpd1-5", "gpd1-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c10_bus: hs-i2c10-bus {
+			samsung,pins = "gpd2-1", "gpd2-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c11_bus: hs-i2c11-bus {
+			samsung,pins = "gpd2-3", "gpd2-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c4_bus: hs-i2c4-bus {
+			samsung,pins = "gpd3-1", "gpd3-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c5_bus: hs-i2c5-bus {
+			samsung,pins = "gpd3-3", "gpd3-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		ufs_rst_n: ufs-rst-n {
+			samsung,pins = "gpi0-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		ufs_refclk_out: ufs-refclk-out {
+			samsung,pins = "gpi0-5";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		decon_f_te_on: decon_f_te_on {
+			samsung,pins = "gpb0-1";
+			samsung,pin-function = <2>;
+		};
+
+		decon_f_te_off: decon_f_te_off {
+			samsung,pins = "gpb0-1";
+			samsung,pin-function = <0>;
+		};
+
+		decon_s_te_on: decon_s_te_on {
+			samsung,pins = "gpb0-2";
+			samsung,pin-function = <2>;
+		};
+
+		decon_s_te_off: decon_s_te_off {
+			samsung,pins = "gpb0-2";
+			samsung,pin-function = <0>;
+		};
+
+		pwm_tout0: pwm-tout0 {
+			samsung,pins = "gpd0-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <1>;
+			samsung,pin-drv = <0>;
+		};
+
+		pwm_tout1: pwm-tout1 {
+			   samsung,pins = "gpd0-5";
+			   samsung,pin-function = <2>;
+			   samsung,pin-pud = <1>;
+			   samsung,pin-drv = <0>;
+		};
+	};
+
+	/* PERIC1 */
+	pinctrl@14CC0000 {
+		uart1_bus: uart1-bus {
+			samsung,pins = "gpe0-3", "gpe0-2", "gpe0-1", "gpe0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		uart1_default: uart1-default {
+			samsung,pins = "gpe0-3", "gpe0-2", "gpe0-1", "gpe0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <3>;
+			samsung,pin-drv = <3>;
+		};
+
+		uart1_btsleep: uart1-btsleep {
+			samsung,pins = "gpe0-3", "gpe0-2", "gpe0-1", "gpe0-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <3>;
+			samsung,pin-drv = <0>;
+		};
+
+		uart2_bus: uart2-bus {
+			samsung,pins = "gpe0-5", "gpe0-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		uart3_bus: uart3-bus {
+			samsung,pins = "gpe0-7", "gpe0-6";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		uart4_bus: uart4-bus {
+			samsung,pins = "gpe1-3", "gpe1-2", "gpe1-1", "gpe1-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		uart5_bus: uart5-bus {
+			samsung,pins = "gpe1-7", "gpe1-6", "gpe1-5", "gpe1-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+		};
+
+		hs_i2c2_bus: hs-i2c2-bus {
+			samsung,pins = "gpe5-1", "gpe5-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c3_bus: hs-i2c3-bus {
+			samsung,pins = "gpe5-3", "gpe5-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c8_bus: hs-i2c8-bus {
+			samsung,pins = "gpe5-5", "gpe5-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c12_bus: hs-i2c12-bus {
+			samsung,pins = "gpe5-7", "gpe5-6";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c13_bus: hs-i2c13-bus {
+			samsung,pins = "gpe6-1", "gpe6-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <0>;
+		};
+
+		hs_i2c14_bus: hs-i2c14-bus {
+			samsung,pins = "gpe6-3", "gpe6-2";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <0>;
+			samsung,pin-drv = <2>;
+		};
+
+		pcie0_clkreq: pcie0_clkreq {
+			samsung,pins = "gpj1-0";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <3>;
+			samsung,pin-drv = <3>;
+			samsung,pin-con-pdn = <3>;
+			samsung,pin-pud-pdn = <3>;
+		};
+
+		pcie0_clkreq_output: pcie0_clkreq_output {
+			samsung,pins = "gpj1-0";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <3>;
+			samsung,pin-drv = <3>;
+			samsung,pin-con-pdn = <3>;
+			samsung,pin-pud-pdn = <3>;
+			samsung,pin-val = <1>;
+		};
+
+		pcie0_perst: pcie0_perst {
+			samsung,pins = "gpj1-2";
+			samsung,pin-function = <1>;
+			samsung,pin-drv = <3>;
+			samsung,pin-con-pdn = <3>;
+		};
+
+		pcie1_clkreq: pcie1_clkreq {
+			samsung,pins = "gpj1-4";
+			samsung,pin-function = <2>;
+			samsung,pin-pud = <3>;
+			samsung,pin-drv = <3>;
+			samsung,pin-con-pdn = <3>;
+			samsung,pin-pud-pdn = <3>;
+		};
+
+		pcie1_clkreq_output: pcie1_clkreq_output {
+			samsung,pins = "gpj1-4";
+			samsung,pin-function = <1>;
+			samsung,pin-pud = <3>;
+			samsung,pin-drv = <3>;
+			samsung,pin-con-pdn = <3>;
+			samsung,pin-pud-pdn = <3>;
+			samsung,pin-val = <1>;
+		};
+
+		pcie1_perst: pcie1_perst {
+			samsung,pins = "gpj1-6";
+			samsung,pin-function = <1>;
+			samsung,pin-drv = <3>;
+			samsung,pin-con-pdn = <3>;
+		};
+	};
+};

--- a/arch/arm/dts/exynos8890.dtsi
+++ b/arch/arm/dts/exynos8890.dtsi
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Samsung Exynos7880 SoC device tree source
+ *
+ * Copyright (c) 2022 Suraaj Vashisht (suraajvashisht@gmail.com)
+ */
+
+/dts-v1/;
+#include "skeleton.dtsi"
+#include "exynos8890-pinctrl.dtsi"
+#include "exynos8890-gpio.dtsi"
+/ {
+	compatible = "samsung,exynos8890";
+
+	fin_pll: xxti {
+		compatible = "fixed-clock";
+		clock-output-names = "fin_pll";
+		u-boot,dm-pre-reloc;
+		#clock-cells = <0>;
+	};
+
+	/* Dummy clock for uart */
+	fin_uart: uart_dummy_fin {
+		compatible = "fixed-clock";
+		clock-output-names = "fin_uart";
+		clock-frequency = <132710400>;
+		u-boot,dm-pre-reloc;
+		#clock-cells = <0>;
+	};
+
+	uart2: serial@13820000 {
+		compatible = "samsung,exynos4210-uart";
+		reg = <0x13820000 0x100>;
+		u-boot,dm-pre-reloc;
+		clocks = <&fin_uart>, <&fin_uart>; // driver uses 1st clock
+		clock-names = "uart", "clk_uart_baud0";
+		pinctrl-names = "default";
+		pinctrl-0 = <&uart2_bus>;
+	};
+
+	gpioi2c0: i2c-0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "i2c-gpio";
+		status = "disabled";
+		gpios = <
+			&gpd1 0 0 /* sda */
+			&gpd1 1 0 /* scl */
+		>;
+		i2c-gpio,delay-us = <5>;
+
+		s2mu004@3d {
+			compatible = "samsung,s2mu004mfd";
+		};
+	};
+
+	/* ALIVE */
+	pinctrl_0: pinctrl@10580000 {
+		compatible = "samsung,exynos8890-pinctrl";
+		reg = <0x10580000 0x1000>;
+	};
+
+	/* AUD */
+	pinctrl_1: pinctrl@114B0000 {
+		compatible = "samsung,exynos8890-pinctrl";
+		reg = <0x114B0000 0x1000>;
+	};
+
+	/* CCORE */
+	pinctrl_2: pinctrl@105A0000 {
+		compatible = "samsung,exynos8890-pinctrl";
+		reg = <0x105A0000 0x1000>;
+	};
+
+	/* FSYS1 */
+	pinctrl_6: pinctrl@15690000 {
+		compatible = "samsung,exynos8890-pinctrl";
+		reg = <0x15690000 0x1000>;
+	};
+
+	/* PERIC0 */
+	pinctrl_8: pinctrl@136D0000 {
+		compatible = "samsung,exynos8890-pinctrl";
+		reg = <0x136D0000 0x1000>;
+	};
+
+	/* PERIC1 */
+	pinctrl_9: pinctrl@14CC0000 {
+		compatible = "samsung,exynos8890-pinctrl";
+		reg = <0x14CC0000 0x1000>;
+	};
+
+	/* ALIVE */
+	gpio_0: gpio@10580000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x10580000 0x1000>;
+	};
+
+	/* AUD */
+	gpio_1: gpio@114B0000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x114B0000 0x1000>;
+	};
+
+	/* CCORE */
+	gpio_2: gpio@105A0000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x105A0000 0x1000>;
+	};
+
+	/* FP */
+	gpio_4: gpio@14CA0000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x14CA0000 0x1000>;
+	};
+
+	/* FSYS0 */
+	gpio_5: gpio@10E60000 {
+		compatible = "samsung,exynos8890-gpio"
+		reg = <0x10E60000 0x1000>;
+	};
+
+	/* FSYS1 */
+	gpio_6: gpio@15690000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x15690000 0x1000>;
+	};
+
+	/* PERIC0 */
+	gpio_8: gpio@136D0000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x136D0000 0x1000>;
+	};
+
+	/* PERIC1 */
+	gpio_9: gpio@14CC0000 {
+		compatible = "samsung,exynos8890-gpio";
+		reg = <0x14CC0000 0x1000>;
+	};
+};

--- a/arch/arm/mach-exynos/mmu-arm64.c
+++ b/arch/arm/mach-exynos/mmu-arm64.c
@@ -95,4 +95,37 @@ static struct mm_region exynos7880_mem_map[] = {
 };
 
 struct mm_region *mem_map = exynos7880_mem_map;
+
+#elif CONFIG_IS_ENABLED(EXYNOS8890)
+
+static struct mm_region exynos8890_mem_map[] = {
+	{
+		.virt	= 0x10000000UL,
+		.phys	= 0x10000000UL,
+		.size	= 0x10000000UL,
+		.attrs	= PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
+				PTE_BLOCK_NON_SHARE |
+				PTE_BLOCK_PXN | PTE_BLOCK_UXN,
+	},
+	{
+		.virt	= 0x40000000UL,
+		.phy	= 0x80000000UL,
+		.size	= 0x80000000UL,
+		.attrs	= PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+				PTE_BLOCK_INNER_SHARE,
+	},
+	{
+		.virt	= 0x80000000UL,
+		.phy	= 0x880000000UL,
+		.size	= 0x80000000UL,
+		.attrs	= PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+				PTE_BLOCK_INNER_SHARE,
+	},
+
+	{
+		/* List terminator */
+	},
+};
+
+struct mm_region *mem_map = exynos8890_mem_map;
 #endif

--- a/drivers/gpio/s5p_gpio.c
+++ b/drivers/gpio/s5p_gpio.c
@@ -358,6 +358,7 @@ static const struct udevice_id exynos_gpio_ids[] = {
 	{ .compatible = "samsung,exynos5250-pinctrl" },
 	{ .compatible = "samsung,exynos5420-pinctrl" },
 	{ .compatible = "samsung,exynos78x0-gpio" },
+	{ .compatible = "samsung,exynos8890-gpio"}
 	{ }
 };
 

--- a/drivers/pinctrl/exynos/Kconfig
+++ b/drivers/pinctrl/exynos/Kconfig
@@ -16,3 +16,11 @@ config PINCTRL_EXYNOS78x0
 	help
 	  Support pin multiplexing and pin configuration control on
 	  Samsung's Exynos78x0 SoC.
+
+config PINCTRL_EXYNOS8890
+	bool "Samsung Exynos8890 pinctrl driver"
+	depends on ARCH_EXYNOS && PINCTRL_FULL
+	select PINCTRL_EXYNOS
+	help
+	  Support pin multiplexing and pin configuration control on
+	  Samsung's Exynos8890 SoC.

--- a/drivers/pinctrl/exynos/Makefile
+++ b/drivers/pinctrl/exynos/Makefile
@@ -6,3 +6,4 @@
 obj-$(CONFIG_PINCTRL_EXYNOS)		+= pinctrl-exynos.o
 obj-$(CONFIG_PINCTRL_EXYNOS7420)	+= pinctrl-exynos7420.o
 obj-$(CONFIG_PINCTRL_EXYNOS78x0)	+= pinctrl-exynos78x0.o
+obj-$(CONFIG_PINCTRL_EXYNOS8890)	+= pinctrl-exynos8890.o

--- a/drivers/pinctrl/exynos/pinctrl-exynos8890.c
+++ b/drivers/pinctrl/exynos/pinctrl-exynos8890.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Exynos8890 pinctrl driver.
+ *
+ * Copyright (c) 2022 Suraaj Vashisht (suraajvashisht@gmail.com)
+ *
+ * based on drivers/pinctrl/exynos/pinctrl-exynos7420.c :
+ * Copyright (C) 2016 Samsung Electronics
+ * Thomas Abraham <thomas.ab@samsung.com>
+ */
+
+#include <command.h>
+#include <dm.h>
+#include <errno.h>
+#include <asm/io.h>
+#include <dm/pinctrl.h>
+#include <dm/root.h>
+#include <fdtdec.h>
+#include <asm/arch/pinmux.h>
+#include "pinctrl-exynos.h"
+
+static const struct pinctrl_ops exynos8890_pinctrl_ops = {
+	.set_state = exynos_pinctrl_set_state
+};
+
+/* pin banks of exynos8890 pin-controller 0 (ALIVE) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks0[] = {
+	EXYNOS_PIN_BANK(8, 0x000, "gpa0"),
+	EXYNOS_PIN_BANK(8, 0x020, "gpa1"),
+	EXYNOS_PIN_BANK(8, 0x040, "gpa2"),
+	EXYNOS_PIN_BANK(8, 0x060, "gpa3"),
+};
+
+/* pin banks of exynos8890 pin-controller 1 (AUD) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks1[] = {
+	EXYNOS_PIN_BANK(7, 0x000, "gph0"),
+};
+
+/* pin banks of exynos8890 pin-controller 2 (CCORE) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks2[] = {
+	EXYNOS_PIN_BANK(2, 0x000, "etc0"),
+};
+
+/* pin banks of exynos8890 pin-controller 4 (FP) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks4[] = {
+	EXYNOS_PIN_BANK(4, 0x000, "gpf2"),
+};
+
+/* pin banks of exynos8890 pin-controller 5 (FSYS0) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks5[] = {
+	EXYNOS_PIN_BANK(4, 0x000, "gpi1"),
+	EXYNOS_PIN_BANK(8, 0x020, "gpi2"),
+};
+
+/* pin banks of exynos8890 pin-controller 6 (FSYS1) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks6[] = {
+	EXYNOS_PIN_BANK(7, 0x000, "gpj0"),
+};
+
+/* pin banks of exynos8890 pin-controller 8 (PERIC0) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks8[] = {
+	EXYNOS_PIN_BANK(6, 0x000, "gpi0"),
+	EXYNOS_PIN_BANK(8, 0x020, "gpd0"),
+	EXYNOS_PIN_BANK(6, 0x040, "gpd1"),
+	EXYNOS_PIN_BANK(4, 0x060, "gpd2"),
+	EXYNOS_PIN_BANK(4, 0x080, "gpd3"),
+	EXYNOS_PIN_BANK(2, 0x0A0, "gpb1"),
+	EXYNOS_PIN_BANK(2, 0x0C0, "gpb2"),
+	EXYNOS_PIN_BANK(3, 0x0E0, "gpb0"),
+	EXYNOS_PIN_BANK(5, 0x100, "gpc0"),
+	EXYNOS_PIN_BANK(5, 0x120, "gpc1"),
+	EXYNOS_PIN_BANK(6, 0x140, "gpc2"),
+	EXYNOS_PIN_BANK(8, 0x160, "gpc3"),
+	EXYNOS_PIN_BANK(4, 0x180, "gpk0"),
+	EXYNOS_PIN_BANK(7, 0x1A0, "etc1"),
+};
+
+/* pin banks of exynos8890 pin-controller 9 (PERIC1) */
+static const struct samsung_pin_bank_data exynos8890_pin_banks9[] = {
+	EXYNOS_PIN_BANK(8, 0x000, "gpe0"),
+	EXYNOS_PIN_BANK(8, 0x020, "gpe5"),
+	EXYNOS_PIN_BANK(8, 0x040, "gpe6"),
+	EXYNOS_PIN_BANK(8, 0x060, "gpj1"),
+	EXYNOS_PIN_BANK(2, 0x080, "gpj2"),
+	EXYNOS_PIN_BANK(8, 0x0A0, "gpe2"),
+	EXYNOS_PIN_BANK(8, 0x0C0, "gpe3"),
+	EXYNOS_PIN_BANK(8, 0x0E0, "gpe4"),
+	EXYNOS_PIN_BANK(8, 0x100, "gpe1"),
+	EXYNOS_PIN_BANK(4, 0x120, "gpe7"),
+	EXYNOS_PIN_BANK(3, 0x140, "gpg0"),
+};
+
+const struct samsung_pin_ctrl exynos8890_pin_ctrl[] = {
+	{
+		/* pin-controller instance 0 ALIVE data */
+		.pin_banks  = exynos8890_pin_banks0,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks0),
+	}, {
+		/* pin-controller instance 1 AUD data */
+		.pin_banks  = exynos8890_pin_banks1,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks1),
+	}, {
+		/* pin-controller instance 2 CCORE data */
+		.pin_banks  = exynos8890_pin_banks2,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks2),
+	}, {
+		/* pin-controller instance 4 FP data */
+		.pin_banks  = exynos8890_pin_banks4,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks4),
+	}, {
+		/* pin-controller instance 5 FSYS0 data */
+		.pin_banks  = exynos8890_pin_banks5,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks5),
+	}, {
+		/* pin-controller instance 6 FSYS1 data */
+		.pin_banks  = exynos8890_pin_banks6,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks6),
+	}, {
+		/* pin-controller instance 8 PERIC0 data */
+		.pin_banks  = exynos8890_pin_banks8,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks8),
+	}, {
+		/* pin-controller instance 9 PERIC1 data */
+		.pin_banks  = exynos8890_pin_banks9,
+		.nr_banks   = ARRAY_SIZE(exynos8890_pin_banks9),
+	},
+	{/* list termiantor */}
+};
+
+static const struct udevice_id exynos8890_pinctrl_ids[] = {
+	{ .compatible = "samsung,exynos8890-pinctrl",
+		.data = (ulong)exynos8890_pin_ctrl },
+	{ }
+};
+
+U_BOOT_DRIVER(pinctrl_exynos8890) = {
+	.name		= "pinctrl_exynos8890",
+	.id		= UCLASS_PINCTRL,
+	.of_match	= exynos8890_pinctrl_ids,
+	.priv_auto = sizeof(struct exynos_pinctrl_priv),
+	.ops		= &exynos8890_pinctrl_ops,
+	.probe		= exynos_pinctrl_probe,
+};

--- a/include/configs/exynos8890-common.h
+++ b/include/configs/exynos8890-common.h
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * Configuration settings for the EXYNOS 8890 based boards.
+ *
+ * Copyright (c) 2022 Suraaj Vashisht (suraajvashisht@gmail.com)
+ * based on include/exynos7420-common.h
+ * Copyright (C) 2016 Samsung Electronics
+ * Thomas Abraham <thomas.ab@samsung.com>
+ */
+
+#ifndef __CONFIG_EXYNOS8890_COMMON_H
+#define __CONFIG_EXYNOS8890_COMMON_H
+
+#include <asm/arch/cpu.h>		/* get chip and board defs */
+#include <linux/sizes.h>
+
+/* Miscellaneous configurable options */
+
+#define CPU_RELEASE_ADDR		secondary_boot_addr
+
+#define CONFIG_SYS_BAUDRATE_TABLE \
+	{9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600}
+
+#define CONFIG_SYS_SDRAM_BASE		0x80000000
+/* DRAM Memory Banks */
+#define SDRAM_BANK_SIZE		(256UL << 20UL)	/* 256 MB */
+#define PHYS_SDRAM_1		CONFIG_SYS_SDRAM_BASE
+#define PHYS_SDRAM_1_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_2		(CONFIG_SYS_SDRAM_BASE + SDRAM_BANK_SIZE)
+#define PHYS_SDRAM_2_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_3		(CONFIG_SYS_SDRAM_BASE + (2 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_3_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_4		(CONFIG_SYS_SDRAM_BASE + (3 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_4_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_5		(CONFIG_SYS_SDRAM_BASE + (4 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_5_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_6		(CONFIG_SYS_SDRAM_BASE + (5 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_6_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_7		(CONFIG_SYS_SDRAM_BASE + (6 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_7_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_8		(CONFIG_SYS_SDRAM_BASE + (7 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_8_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_9		(CONFIG_SYS_SDRAM_BASE + (8 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_9_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_10		(CONFIG_SYS_SDRAM_BASE + (9 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_10_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_11		(CONFIG_SYS_SDRAM_BASE + (10 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_11_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_12		(CONFIG_SYS_SDRAM_BASE + (11 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_12_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_13		(CONFIG_SYS_SDRAM_BASE + (12 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_13_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_14		(CONFIG_SYS_SDRAM_BASE + (13 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_14_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_15		(CONFIG_SYS_SDRAM_BASE + (14 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_15_SIZE	SDRAM_BANK_SIZE
+#define PHYS_SDRAM_16		(CONFIG_SYS_SDRAM_BASE + (15 * SDRAM_BANK_SIZE))
+#define PHYS_SDRAM_16_SIZE	SDRAM_BANK_SIZE
+
+#ifndef MEM_LAYOUT_ENV_SETTINGS
+#define MEM_LAYOUT_ENV_SETTINGS \
+	"bootm_size=0x10000000\0" \
+	"bootm_low=0x80000000\0"
+#endif
+
+#ifndef EXYNOS_DEVICE_SETTINGS
+#define EXYNOS_DEVICE_SETTINGS \
+	"stdin=serial\0" \
+	"stdout=serial\0" \
+	"stderr=serial\0"
+#endif
+
+#ifndef EXYNOS_FDTFILE_SETTING
+#define EXYNOS_FDTFILE_SETTING
+#endif
+
+/* Cannot use bootdelay > 0, because timer is not working */
+#define EXTRA_ENV_SETTINGS \
+	"bootdelay=0\0" \
+	"bootcmd=source $prevbl_initrd_start_addr:bootscript\0"	\
+	EXYNOS_DEVICE_SETTINGS \
+	EXYNOS_FDTFILE_SETTING \
+	MEM_LAYOUT_ENV_SETTINGS
+
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	EXTRA_ENV_SETTINGS
+
+#endif	/* __CONFIG_EXYNOS8890_COMMON_H */


### PR DESCRIPTION
Samsung Exynos 8890 -  SoC for mainstream smartphones introduced in November 2015.
Features:
- 4 Exynos M1 cores
- 4 Cortext A53 cores
- ARM Mali-T880 MP12 GPU

Signed-off-by: Suraaj Vashisht <suraajvashisht@gmail.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
